### PR TITLE
Home assignment 3

### DIFF
--- a/accounting/Gemfile
+++ b/accounting/Gemfile
@@ -19,6 +19,8 @@ gem "slim"
 gem "karafka"
 gem "waterdrop"
 
+gem "schema_registry", path: "../event_schema_registry/ruby/"
+
 group :development, :test do
   gem 'pry'
 end

--- a/accounting/Gemfile.lock
+++ b/accounting/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: ../event_schema_registry/ruby
+  specs:
+    schema_registry (1)
+      json-schema
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,6 +66,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -143,6 +151,8 @@ GEM
       reline (>= 0.2.7)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jwt (2.3.0)
     karafka (1.4.10)
       dry-configurable (~> 0.13)
@@ -196,6 +206,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -301,6 +312,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 6.1.4, >= 6.1.4.1)
   sass-rails (>= 6)
+  schema_registry!
   slim
   spring
   sqlite3 (~> 1.4)

--- a/accounting/app/consumers/tasks_consumer.rb
+++ b/accounting/app/consumers/tasks_consumer.rb
@@ -1,0 +1,19 @@
+class TasksConsumer < ApplicationConsumer
+  def consume
+    params_batch.each do |message|
+      data = message.payload["data"]
+
+      case message.payload["event_name"]
+      when "TaskAssigned"
+        task = Task.find_by(public_id: data["public_id"])
+        account = Account.find_by(public_id: data["assignee_id"]).balance
+        Transaction.create!(title: "For task assigning", task: task, balance: account.balance, amount: -task.cost)
+        account.update!(balance: account.balance - task.cost)
+      when "TaskCompleted"
+        task = Task.find_by(public_id: data["public_id"])
+        account = Account.find_by(public_id: task.assignee_id)
+        Transaction.create!(title: "For task completing", task: task, account: account, amount: task.reward)
+      end
+    end
+  end
+end

--- a/accounting/app/consumers/tasks_stream_consumer.rb
+++ b/accounting/app/consumers/tasks_stream_consumer.rb
@@ -1,0 +1,24 @@
+class TasksStreamConsumer < ApplicationConsumer
+  def consume
+    params_batch.each do |message|
+      payload = message.payload
+      data = payload["data"]
+
+      case payload["event_name"]
+      when "TaskCreated"
+        task = Task.upsert(public_id: data["public_id"])
+        task.update!(
+          assignee_id: data["assignee_id"],
+          creator_id: data["creator_id"],
+          status: data["status"],
+          description: data["description"],
+          cost: rand(10..20),
+          reward: rand(20..40)
+        )
+      when "TaskUpdated"
+        task = Task.upsert(public_id: data["public_id"])
+        task.update!(assignee_id: data["assignee_id"], status: data["status"])
+      end
+    end
+  end
+end

--- a/accounting/app/controllers/accounts_controller.rb
+++ b/accounting/app/controllers/accounts_controller.rb
@@ -1,0 +1,6 @@
+class AccountsController < ApplicationController
+  def index
+    @accounts = Account.all
+    @earning_money = - Task.today.done.pluck(:reward).sum + Task.today.pluck(:cost).sum
+  end
+end

--- a/accounting/app/controllers/transactions_controller.rb
+++ b/accounting/app/controllers/transactions_controller.rb
@@ -1,0 +1,11 @@
+class TransactionsController < ApplicationController
+  def index
+    @transactions = account.transactions.today
+  end
+
+  private
+
+  def account
+    Account.find(params[:account_id])
+  end
+end

--- a/accounting/app/models/account.rb
+++ b/accounting/app/models/account.rb
@@ -2,4 +2,7 @@ class Account < ApplicationRecord
   ROLES = %w(admin dev).freeze
 
   enum role: ROLES.zip(ROLES).to_h
+
+  has_many :tasks
+  has_many :transactions
 end

--- a/accounting/app/models/task.rb
+++ b/accounting/app/models/task.rb
@@ -1,0 +1,10 @@
+class Task < ApplicationRecord
+  STATUSES = %w(created done ptichka_v_kletke proso_v_miske).freeze
+
+  belongs_to :account
+  belongs_to :assignee, class_name: "Account"
+
+  enum status: STATUSES.zip(STATUSES).to_h, _default: "created"
+
+  scope :today, -> { where(created_at: Date.current.beginning_of_day..Date.current.end_of_day) }
+end

--- a/accounting/app/models/transaction.rb
+++ b/accounting/app/models/transaction.rb
@@ -1,0 +1,10 @@
+class Transaction < ApplicationRecord
+  STATUSES = %w(pending completed).freeze
+
+  belongs_to :task
+  belongs_to :account
+
+  enum status: STATUSES.zip(STATUSES).to_h, _default: "pending"
+
+  scope :today, -> { where(created_at: Date.current.beginning_of_day..Date.current.end_of_day) }
+end

--- a/accounting/app/views/accounts/index.slim
+++ b/accounting/app/views/accounts/index.slim
@@ -1,0 +1,28 @@
+- if current_account
+  = link_to "Sign out", destroy_account_session_path, method: :delete
+- else
+  = link_to "Sign in", new_account_session_path
+
+hr
+  h2 Business earning money:
+  = @earning_money
+hr
+
+h1 Accounts
+
+table
+  thead
+    tr
+      th PublicId
+      th Email
+      th Balance
+      th
+  tbody
+    - @accounts.each do |account|
+      tr
+        td = account.public_id
+        td = account.email
+        td = account.balance
+        td
+          - if current_account == account
+            = link_to "Transaction logs", account_transactions_path(account)

--- a/accounting/app/views/transactions/index.slim
+++ b/accounting/app/views/transactions/index.slim
@@ -1,0 +1,23 @@
+- if current_account
+  = link_to "Sign out", destroy_account_session_path, method: :delete
+- else
+  = link_to "Sign in", new_account_session_path
+
+hr
+
+h1 Transactions
+
+table
+  thead
+    tr
+      th Title
+      th Status
+      th Amount
+      th
+  tbody
+    - @transactions.each do |transaction|
+      tr
+        td = transaction.title
+        td = transaction.status.humanize
+        td = transaction.amount
+

--- a/accounting/config/routes.rb
+++ b/accounting/config/routes.rb
@@ -2,4 +2,7 @@ Rails.application.routes.draw do
   get "/auth/:provider/callback", to: "sessions#create"
 
   resource :sessions
+  resources :accounts do
+    resources :transactions, only: %w(index)
+  end
 end

--- a/accounting/db/migrate/20211114105542_create_accounts.rb
+++ b/accounting/db/migrate/20211114105542_create_accounts.rb
@@ -4,6 +4,7 @@ class CreateAccounts < ActiveRecord::Migration[6.1]
       t.string :email
       t.string :public_id
       t.string :role
+      t.integer :balance
 
       t.timestamps
     end

--- a/accounting/db/migrate/20211114145234_create_transactions.rb
+++ b/accounting/db/migrate/20211114145234_create_transactions.rb
@@ -1,0 +1,13 @@
+class CreateTransactions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :transactions do |t|
+      t.string :title
+      t.bigint :account_id
+      t.bigint :task_id
+      t.integer :amount
+      t.string :status
+
+      t.timestamps
+    end
+  end
+end

--- a/accounting/db/migrate/20211114145743_create_tasks.rb
+++ b/accounting/db/migrate/20211114145743_create_tasks.rb
@@ -9,6 +9,9 @@ class CreateTasks < ActiveRecord::Migration[6.1]
       t.string :status
       t.text :description
 
+      t.integer :cost, null: false, default: 0
+      t.integer :reward, null: false, default: 0
+
       t.timestamps
     end
   end

--- a/accounting/db/schema.rb
+++ b/accounting/db/schema.rb
@@ -10,12 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_14_105542) do
+ActiveRecord::Schema.define(version: 2021_11_14_145743) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "email"
     t.string "public_id"
     t.string "role"
+    t.integer "balance"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "public_id"
+    t.bigint "assignee_id"
+    t.bigint "creator_id"
+    t.string "status"
+    t.text "description"
+    t.integer "cost", default: 0, null: false
+    t.integer "reward", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "transactions", force: :cascade do |t|
+    t.string "title"
+    t.bigint "account_id"
+    t.bigint "task_id"
+    t.integer "amount"
+    t.string "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/accounting/karafka.rb
+++ b/accounting/karafka.rb
@@ -41,18 +41,13 @@ class KarafkaApp < Karafka::App
       consumer AccountsStreamConsumer
     end
 
-    # topic :example do
-    #   consumer ExampleConsumer
-    # end
-    # consumer_group :bigger_group do
-    #   topic :test do
-    #     consumer TestConsumer
-    #   end
-    #
-    #   topic :test2 do
-    #     consumer Test2Consumer
-    #   end
-    # end
+    topic "tasks" do
+      consumer TasksConsumer
+    end
+
+    topic "tasks-stream" do
+      consumer TasksStreamConsumer
+    end
   end
 end
 

--- a/auth/Gemfile
+++ b/auth/Gemfile
@@ -16,6 +16,8 @@ gem "devise"
 gem "doorkeeper"
 gem "waterdrop"
 
+gem "schema_registry", path: "../event_schema_registry/ruby/"
+
 group :development, :test do
   gem 'pry'
 end

--- a/auth/Gemfile.lock
+++ b/auth/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: ../event_schema_registry/ruby
+  specs:
+    schema_registry (1)
+      json-schema
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,6 +66,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bcrypt (3.1.16)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
@@ -122,6 +130,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -144,6 +154,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -249,6 +260,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 6.1.4, >= 6.1.4.1)
   sass-rails (>= 6)
+  schema_registry!
   slim
   spring
   sqlite3 (~> 1.4)

--- a/auth/app/controllers/registrations_controller.rb
+++ b/auth/app/controllers/registrations_controller.rb
@@ -4,10 +4,20 @@ class RegistrationsController < Devise::RegistrationsController
     resource.update!(role: :admin)
 
     event = {
+      event_id: SecureRandom.uuid,
+      event_version: "1",
       event_name: 'AccountCreated',
+      event_time: Time.now.to_s,
+      producer: 'auth_service',
       data: { public_id: resource.public_id, email: resource.email, role: resource.role }
     }
 
-    KafkaProducer.produce_sync(topic: 'accounts-stream', payload: event.to_json)
+    result = SchemaRegistry.validate_event(event, 'accounts.created', version: 1)
+
+    if result.success?
+      KafkaProducer.produce_sync(topic: 'accounts-stream', payload: event.to_json)
+    else
+      raise result.failure
+    end
   end
 end

--- a/tasks/Gemfile
+++ b/tasks/Gemfile
@@ -19,6 +19,8 @@ gem "slim"
 gem "karafka"
 gem "waterdrop"
 
+gem "schema_registry", path: "../event_schema_registry/ruby/"
+
 group :development, :test do
   gem 'pry'
 end

--- a/tasks/Gemfile.lock
+++ b/tasks/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: ../event_schema_registry/ruby
+  specs:
+    schema_registry (1)
+      json-schema
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,6 +66,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -143,6 +151,8 @@ GEM
       reline (>= 0.2.7)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jwt (2.3.0)
     karafka (1.4.10)
       dry-configurable (~> 0.13)
@@ -196,6 +206,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -301,6 +312,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 6.1.4, >= 6.1.4.1)
   sass-rails (>= 6)
+  schema_registry!
   slim
   spring
   sqlite3 (~> 1.4)


### PR DESCRIPTION
Из того что сделано:
- Пременил schema registry для формализации схемы (валидирую все отправляемые параметры)
- Добавил сервис `accounting` и `analytics`, сделал авторизацию
- Написал часть функционала по подсчёту денег в аккаунтинге (нету закрытия дня)
- Расписал процесс эволюции данных (ниже)
- Расписал стратегию обработки ошибок.
Осталось сделать:
- Дописать функционал закрытия дня в аккаунтинге + отправка событий.
- Сохранение всех CUD событий в Аналитке и отображение результатов

### Процесс миграции на `title`+`jira_id`:
1. Добавить новую схему 
2. Обновить консьюмеры для поддержки новой версии схемы (добавление колонок в таблицу, возможность записи в них)
3. Перевести продюссер на работу с новой версией
4. Написать одноразовый скрипт, который разделит на title + jira_id данные в основной таблице и простримет их в очередь
5. Подчистить код, от остатков не нужной функциональности. (можем удалить поддержку в консьюмерах старой версии?)

---
### Процесс миграции на новые статусы:
Есть `простой` и `сложный` вариант.

`Простой`: Не менять значения в базе, чисто подправить UI. Бизнесу же не важно, что лежит в БД
`Сложный`:
1. Добавить новую схему 
2. Обновить консьюмеры для поддержки новой версии схемы
3. Перевести продюссер на работу с новой версией
4. Написать одноразовый скрипт, который обновит данные в основной ДБ и отправит обновлённые данные в очередь
5. Подчистить код, от остатков не нужной функциональности, удалить не нужные статусы. Убрать поддержку старых версий.

---
### Стратегия обработки ошибок в событиях связанных с системой аккаунтинга.

Мне понравилась идея, что мы можем подстраховаться, есди очередь не будет доступна. Прежде возможные события сначала записывать в БД, а уже после пытаться отправить их.(напомнило wal из pg)
1. Создаём таблицу в Таскс сервисе: produced_events (type, status, payload)
1. Записываем события в таблицу, перед тем, как отправить их. Получилось отправиить, меняем статус, не получилось, так же отмечаем, что не получилось
1. Имеем отдельный сервис, который повторно пытается отправить события (тут нужно понимать, что не все события мы можем отправлять)
1. На стороне аккаунтига, мы так же можем сохранять события (таблица consumed_events (type, status, payload)), которые упали (ну или все события и просто менять статусы).
6. В нашем случае (возёмем самый яркий пример), не можем отправить эвент/не доступен брокер, сохраняем в таблицу, пытаемся отправить, не получается, пробуем через какое-то время ещё раз. Тем временем сохраняем события в базу